### PR TITLE
Fix: ANSI escape codes breaks cursor

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var term = 13; // carriage return
  *   autocomplete: {StringArray} function({String})
  *   history: {String} a history control object (see `prompt-sync-history`)
  * }
- * @returns {Function} prompt function 
+ * @returns {Function} prompt function
  */
 
  // for ANSI escape codes reference see https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -19,7 +19,7 @@ function create(config) {
 
   config = config || {};
   var sigint = config.sigint;
-  var autocomplete = config.autocomplete = 
+  var autocomplete = config.autocomplete =
     config.autocomplete || function(){return []};
   var history = config.history;
   prompt.history = history || {save: function(){}};
@@ -38,9 +38,9 @@ function create(config) {
    *   ask: {String} opening question/statement to prompt for, does not override ask param
    *   autocomplete: {StringArray} function({String})
    * }
-   * 
-   * @returns {string} Returns the string input or (if sigint === false) 
-   *                   null if user terminates with a ^C  
+   *
+   * @returns {string} Returns the string input or (if sigint === false)
+   *                   null if user terminates with a ^C
    */
 
 
@@ -60,7 +60,7 @@ function create(config) {
     var masked = 'echo' in opts;
     autocomplete = opts.autocomplete || autocomplete;
 
-    var fd = (process.platform === 'win32') ? 
+    var fd = (process.platform === 'win32') ?
       process.stdin.fd :
       fs.openSync('/dev/tty', 'rs');
 
@@ -100,7 +100,7 @@ function create(config) {
             if (masked) break;
             if (!history) break;
             if (history.pastEnd()) break;
-            
+
             if (history.atPenultimate()) {
               str = savedstr;
               insert = savedinsert;
@@ -222,7 +222,7 @@ function create(config) {
           process.stdout.write('\u001b[2K\u001b[0G'+ str + '\u001b[' + (str.length - insert) + 'D');
         }
       }
-      
+
       // Reposition the cursor to the right of the insertion point
       process.stdout.write(`\u001b[${ask.length+1+(echo==''? 0:insert)}G`);
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var fs = require('fs');
+var stripAnsi = require('strip-ansi');
 var term = 13; // carriage return
 
 /**
@@ -224,7 +225,8 @@ function create(config) {
       }
 
       // Reposition the cursor to the right of the insertion point
-      process.stdout.write(`\u001b[${ask.length+1+(echo==''? 0:insert)}G`);
+      var askLength = stripAnsi(ask).length;
+      process.stdout.write(`\u001b[${askLength+1+(echo==''? 0:insert)}G`);
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "license": "MIT",
   "devDependencies": {
     "prompt-sync-history": "^1.0.1"
+  },
+  "dependencies": {
+    "strip-ansi": "^5.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,9 @@
 //basic:
 console.log(require('./')()('tell me something about yourself: '))
 
+// ANSI escape codes colored text test
+require('./')()('\u001B[31mcolored text: \u001B[39m');
+
 var prompt = require('./')({
   history: require('prompt-sync-history')(),
   autocomplete: complete(['hello1234', 'he', 'hello', 'hello12', 'hello123456']),


### PR DESCRIPTION
This PR fixes #34 

- Included a (lightweight) dependency to filter out ANSI escape codes before getting the length of `ask`
- Added a test

Also I removed trailing whitespaces.