### PR TITLE
Fix deprecation, handle ^D

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Takes `config` option with the following possible properties
 
 `sigint`: Default is `false`. A ^C may be pressed during the input process to abort the text entry. If sigint it `false`, prompt returns `null`. If sigint is `true` the ^C will be handled in the traditional way: as a SIGINT signal causing process to exit with code 130.
 
+`eot`: Default is `false`. A ^D pressed as the first character of an input line causes prompt-sync to echo `exit` and exit the process with code 0.
+
 `autocomplete`: A completer function that will be called when user enters TAB to allow for autocomplete. It takes a string as an argument an returns an array of strings that are possible matches for completion. An empty array is returned if there are no matches.
 
 `history`: Takes an object that supplies a "history interface", see [prompt-sync-history](http://npm.im/prompt-sync-history) for an example.

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function create(config) {
 
   config = config || {};
   var sigint = config.sigint;
+  var eot = config.eot;
   var autocomplete = config.autocomplete =
     config.autocomplete || function(){return []};
   var history = config.history;
@@ -150,6 +151,14 @@ function create(config) {
         process.stdin.setRawMode && process.stdin.setRawMode(wasRaw);
 
         return null;
+      }
+
+      // catch a ^D and exit
+      if (character == 4) {
+        if (str.length == 0 && eot) {
+          process.stdout.write('exit\n');
+          process.exit(0);
+        }
       }
 
       // catch the terminating character

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function create(config) {
     var wasRaw = process.stdin.isRaw;
     if (!wasRaw) { process.stdin.setRawMode && process.stdin.setRawMode(true); }
 
-    var buf = new Buffer(3);
+    var buf = Buffer.alloc(3);
     var str = '', character, read;
 
     savedstr = '';
@@ -131,7 +131,7 @@ function create(config) {
               insert = str.length;
               promptPrint(masked, ask, echo, str, insert);
               process.stdout.write('\u001b[' + (insert+ask.length+1) + 'G');
-              buf = new Buffer(3);
+              buf = Buffer.alloc(3);
             }
         }
         continue; // any other 3 character sequence is ignored


### PR DESCRIPTION
* `new Buffer()` is deprecated, `Buffer.alloc(3)` should work back to Node 5
* `^D`/`EOT` support can be enabled via `eot` config flag. EOT handling matches the behavior of the bash shell